### PR TITLE
Break-Up[Explicit] - clean up/refactoring

### DIFF
--- a/include/signalrclient/connection.h
+++ b/include/signalrclient/connection.h
@@ -16,7 +16,7 @@ namespace signalr
     class connection
     {
     public:
-        connection(const utility::string_t& url, const utility::string_t& querystring = U(""));
+        explicit connection(const utility::string_t& url, const utility::string_t& querystring = U(""));
 
         connection(const connection&) = delete;
 
@@ -27,10 +27,6 @@ namespace signalr
         SIGNALRCLIENT_API pplx::task<void> start();
 
     private:
-        web::uri m_base_uri;
-        utility::string_t m_querystring;
-
-        // the order is important since the factories are used to create and initialize the connection_impl instance
         web_request_factory m_web_request_factory;
         transport_factory m_transport_factory;
 

--- a/include/signalrclient/transport_factory.h
+++ b/include/signalrclient/transport_factory.h
@@ -14,6 +14,6 @@ namespace signalr
     public:
         std::unique_ptr<transport> virtual create_transport(transport_type transport_type);
 
-        virtual ~transport_factory() {};
+        virtual ~transport_factory();
     };
 }

--- a/include/signalrclient/web_exception.h
+++ b/include/signalrclient/web_exception.h
@@ -12,7 +12,7 @@ namespace signalr
     class web_exception : public std::runtime_error
     {
     public:
-        web_exception(const utility::string_t &what) 
+        explicit web_exception(const utility::string_t &what) 
             : runtime_error(utility::conversions::to_utf8string(what))
         {}
     };

--- a/include/signalrclient/web_request.h
+++ b/include/signalrclient/web_request.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include "web_response.h"
 #include <cpprest\basic_types.h>
 #include <cpprest\base_uri.h>
-#include "web_response.h"
 
 namespace signalr
 {
@@ -17,8 +17,7 @@ namespace signalr
         utility::string_t m_user_agent_string;
 
     public:
-        web_request(const web::uri &url) : m_url(url)
-        {}
+        explicit web_request(const web::uri &url);
 
         virtual void set_method(const utility::string_t &method);
         virtual void set_user_agent(const utility::string_t &user_agent_string);

--- a/include/signalrclient/web_request_factory.h
+++ b/include/signalrclient/web_request_factory.h
@@ -11,12 +11,8 @@ namespace signalr
     class web_request_factory
     {
     public:
-        virtual std::unique_ptr<web_request> create_web_request(const web::uri &url)
-        {
-            return std::make_unique<web_request>(url);
-        }
+        virtual std::unique_ptr<web_request> create_web_request(const web::uri &url);
 
-        virtual ~web_request_factory()
-        {}
+        virtual ~web_request_factory();
     };
 }

--- a/include/signalrclient/web_response.h
+++ b/include/signalrclient/web_response.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <ppl.h>
+#include <ppltasks.h>
 #include <cpprest\basic_types.h>
 
-namespace pplx = concurrency;
+namespace pplx = Concurrency;
 
 namespace signalr
 {

--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj
@@ -120,6 +120,7 @@
     <ClCompile Include="..\..\transport_factory.cpp" />
     <ClCompile Include="..\..\url_builder.cpp" />
     <ClCompile Include="..\..\web_request.cpp" />
+    <ClCompile Include="..\..\web_request_factory.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj.filters
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj.filters
@@ -94,8 +94,11 @@
     </ClCompile>
     <ClCompile Include="..\..\connection.cpp">
       <Filter>Source Files</Filter>
-    </ClCompile>    
+    </ClCompile>
     <ClCompile Include="..\..\transport_factory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\web_request_factory.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/signalrclient/connection.cpp
+++ b/src/signalrclient/connection.cpp
@@ -11,8 +11,9 @@
 namespace signalr
 {
     connection::connection(const utility::string_t& url, const utility::string_t& querystring)
-        : m_base_uri(url), m_querystring(querystring), m_pImpl(new connection_impl(m_web_request_factory, m_transport_factory))
-    {}
+    {
+        m_pImpl = new connection_impl(url, querystring, m_web_request_factory, m_transport_factory);
+    }
 
     connection::~connection()
     {

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -6,6 +6,11 @@
 
 namespace signalr
 {
+    connection_impl::connection_impl(const utility::string_t& url, const utility::string_t& querystring,
+        web_request_factory& web_request_factory, transport_factory& transport_factory)
+        : m_base_uri(url), m_querystring(querystring), m_web_request_factory(web_request_factory), m_transport_factory(transport_factory)
+    { }
+
     pplx::task<void> connection_impl::start()
     {
         return pplx::task_from_result();

--- a/src/signalrclient/connection_impl.h
+++ b/src/signalrclient/connection_impl.h
@@ -12,11 +12,10 @@ namespace signalr
     class connection_impl
     {
     public:
-        // taking references to be able to inject factories for test purposes. The consumer must 
+        // taking references to be able to inject factories for test purposes. The caller must 
         // make sure that actual instances outlive connection_impl
-        connection_impl(web_request_factory& web_request_factory, transport_factory& transport_factory)
-            : m_web_request_factory(web_request_factory), m_transport_factory(transport_factory)
-        { }
+        connection_impl(const utility::string_t& url, const utility::string_t& querystring,
+            web_request_factory& web_request_factory, transport_factory& transport_factory);
 
         connection_impl(const connection_impl&) = delete;
 
@@ -25,6 +24,9 @@ namespace signalr
         pplx::task<void> start();
 
     private:
+        web::uri m_base_uri;
+        utility::string_t m_querystring;
+
         web_request_factory &m_web_request_factory;
         transport_factory& m_transport_factory;
     };

--- a/src/signalrclient/transport_factory.cpp
+++ b/src/signalrclient/transport_factory.cpp
@@ -17,4 +17,6 @@ namespace signalr
         throw std::exception("not implemented");
     }
 
+    transport_factory::~transport_factory()
+    { }
 }

--- a/src/signalrclient/web_request.cpp
+++ b/src/signalrclient/web_request.cpp
@@ -7,6 +7,10 @@
 
 namespace signalr
 {
+    web_request::web_request(const web::uri &url)
+        : m_url(url)
+    {}
+
     void web_request::set_method(const utility::string_t &method)
     {
         m_method = method;

--- a/src/signalrclient/web_request_factory.cpp
+++ b/src/signalrclient/web_request_factory.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "signalrclient\web_request_factory.h"
+
+namespace signalr
+{
+    std::unique_ptr<web_request> web_request_factory::create_web_request(const web::uri &url)
+    {
+        return std::make_unique<web_request>(url);
+    }
+
+    web_request_factory::~web_request_factory()
+    {}
+}

--- a/src/signalrclient/websocket_transport.h
+++ b/src/signalrclient/websocket_transport.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cpprest/ws_client.h>
+#include <cpprest\ws_client.h>
 #include "url_builder.h"
 #include "signalrclient\transport.h"
 
@@ -15,14 +15,14 @@ namespace signalr
     class websocket_transport : public transport
     {
     public:
-        websocket_transport() : websocket_transport(T())
+        explicit websocket_transport() : websocket_transport(T())
         { }
 
-        websocket_transport(T&& websocket_client)
+        explicit websocket_transport(T&& websocket_client)
             : m_websocket_client(std::move(websocket_client))
         { }
 
-        websocket_transport(const T &websocket_client)
+        explicit websocket_transport(const T &websocket_client)
             : m_websocket_client(websocket_client)
         { }
 

--- a/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj
+++ b/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj
@@ -87,6 +87,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\stdafx.h" />
     <ClInclude Include="..\..\targetver.h" />
+    <ClInclude Include="..\..\test_websocket_client.h" />
     <ClInclude Include="..\..\test_web_request_factory.h" />
     <ClInclude Include="..\..\web_request_stub.h" />
   </ItemGroup>
@@ -98,8 +99,11 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\..\test_websocket_client.cpp" />
+    <ClCompile Include="..\..\test_web_request_factory.cpp" />
     <ClCompile Include="..\..\url_builder_tests.cpp" />
     <ClCompile Include="..\..\websocket_transport_tests.cpp" />
+    <ClCompile Include="..\..\web_request_stub.cpp" />
     <ClCompile Include="..\..\web_request_tests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj.filters
+++ b/test/signalrclienttests/Build/VS2013/signalrclienttests.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClInclude Include="..\..\test_web_request_factory.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\test_websocket_client.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\stdafx.cpp">
@@ -48,6 +51,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\websocket_transport_tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\test_web_request_factory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\web_request_stub.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\test_websocket_client.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/test/signalrclienttests/test_web_request_factory.cpp
+++ b/test/signalrclienttests/test_web_request_factory.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "test_web_request_factory.h"
+
+using namespace signalr;
+
+test_web_request_factory::test_web_request_factory(std::function<std::unique_ptr<web_request>(const web::uri &url)> create_web_request_fn)
+    : m_create_web_request_fn(create_web_request_fn)
+{ }
+
+std::unique_ptr<web_request> test_web_request_factory::create_web_request(const web::uri &url)
+{
+    return m_create_web_request_fn(url);
+}

--- a/test/signalrclienttests/test_web_request_factory.h
+++ b/test/signalrclienttests/test_web_request_factory.h
@@ -11,14 +11,9 @@ using namespace signalr;
 class test_web_request_factory : public web_request_factory
 {
 public:
-    test_web_request_factory(std::function<std::unique_ptr<web_request>(const web::uri &url)> create_web_request_fn)
-        : m_create_web_request_fn(create_web_request_fn)
-    { }
+    explicit test_web_request_factory(std::function<std::unique_ptr<web_request>(const web::uri &url)> create_web_request_fn);
 
-    virtual std::unique_ptr<web_request> create_web_request(const web::uri &url) override
-    {
-        return m_create_web_request_fn(url);
-    }
+    virtual std::unique_ptr<web_request> create_web_request(const web::uri &url) override;
 
 private:
     std::function<std::unique_ptr<web_request>(const web::uri &url)> m_create_web_request_fn;

--- a/test/signalrclienttests/test_websocket_client.cpp
+++ b/test/signalrclienttests/test_websocket_client.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "test_websocket_client.h"
+
+test_websocket_client::test_websocket_client() 
+    : m_connect_function([](const web::uri &){ return pplx::task_from_result(); }),
+    m_send_function ([](web_sockets::client::websocket_outgoing_message msg){ return pplx::task_from_result(); }),
+    m_receive_function([](){ return pplx::task_from_result(web_sockets::client::websocket_incoming_message()); }),
+    m_close_function([](){ return pplx::task_from_result(); })
+
+{ }
+
+pplx::task<void> test_websocket_client::connect(const web::uri &url)
+{
+    return m_connect_function(url);
+}
+
+pplx::task<void> test_websocket_client::send(web_sockets::client::websocket_outgoing_message msg)
+{
+    return m_send_function(msg);
+}
+
+pplx::task<web_sockets::client::websocket_incoming_message> test_websocket_client::receive()
+{
+    return m_receive_function();
+}
+
+pplx::task<void> test_websocket_client::close()
+{
+    return m_close_function();
+}
+
+void test_websocket_client::set_connect_function(std::function<pplx::task<void>(const web::uri &url)> connect_function)
+{
+    m_connect_function = connect_function;
+}
+
+void test_websocket_client::set_send_function(std::function<pplx::task<void>(web_sockets::client::websocket_outgoing_message)> send_function)
+{
+    m_send_function = send_function;
+}
+
+void test_websocket_client::set_receive_function(std::function<pplx::task<web_sockets::client::websocket_incoming_message>()> receive_function)
+{
+    m_receive_function = receive_function;
+}
+
+void test_websocket_client::set_close_function(std::function<pplx::task<void>()> close_function)
+{
+    m_close_function = close_function;
+}

--- a/test/signalrclienttests/test_websocket_client.h
+++ b/test/signalrclienttests/test_websocket_client.h
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include <functional>
+#include <cpprest\ws_client.h>
+
+using namespace web::experimental;
+
+class test_websocket_client
+{
+public:
+    test_websocket_client();
+
+    pplx::task<void> connect(const web::uri &url);
+
+    pplx::task<void> send(web_sockets::client::websocket_outgoing_message msg);
+
+    pplx::task<web_sockets::client::websocket_incoming_message> receive();
+
+    pplx::task<void> close();
+
+    void set_connect_function(std::function<pplx::task<void>(const web::uri &url)> connect_function);
+
+    void set_send_function(std::function<pplx::task<void>(web_sockets::client::websocket_outgoing_message)> send_function);
+
+    void set_receive_function(std::function<pplx::task<web_sockets::client::websocket_incoming_message>()> receive_function);
+
+    void set_close_function(std::function<pplx::task<void>()> close_function);
+
+private:
+    std::function<pplx::task<void>(const web::uri &url)> m_connect_function;
+
+    std::function<pplx::task<void>(web_sockets::client::websocket_outgoing_message)> m_send_function;
+
+    std::function<pplx::task<web_sockets::client::websocket_incoming_message>()> m_receive_function;
+
+    std::function<pplx::task<void>()> m_close_function;
+};

--- a/test/signalrclienttests/web_request_stub.cpp
+++ b/test/signalrclienttests/web_request_stub.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "web_request_stub.h"
+
+web_request_stub::web_request_stub(unsigned short status_code, const utility::string_t& reason_phrase, const utility::string_t& response_body)
+    : web_request(web::uri(_XPLATSTR(""))), m_status_code(status_code), m_reason_phrase(reason_phrase), m_response_body(response_body)
+{ }
+
+void web_request_stub::set_method(const utility::string_t &method)
+{
+    m_method = method;
+}
+
+void web_request_stub::set_user_agent(const utility::string_t &user_agent_string)
+{
+    m_user_agent_string = user_agent_string;
+}
+
+pplx::task<web_response> web_request_stub::get_response()
+{
+    return pplx::task_from_result<web_response>(
+        web_response{ m_status_code, m_reason_phrase, pplx::task_from_result<utility::string_t>(m_response_body) });
+}

--- a/test/signalrclienttests/web_request_stub.h
+++ b/test/signalrclienttests/web_request_stub.h
@@ -3,9 +3,8 @@
 
 #pragma once
 
-#include <cpprest\basic_types.h>
-#include "signalrclient\web_response.h"
 #include "signalrclient\web_request.h"
+#include "signalrclient\web_response.h"
 
 using namespace signalr;
 
@@ -17,23 +16,11 @@ struct web_request_stub : public web_request
     utility::string_t m_method;
     utility::string_t m_user_agent_string;
 
-    web_request_stub(unsigned short status_code, const utility::string_t& reason_phrase, const utility::string_t& response_body = _XPLATSTR(""))
-        : web_request(web::uri(_XPLATSTR(""))), m_status_code(status_code), m_reason_phrase(reason_phrase), m_response_body(response_body)
-    { }
+    web_request_stub(unsigned short status_code, const utility::string_t& reason_phrase, const utility::string_t& response_body = _XPLATSTR(""));
 
-    virtual void set_method(const utility::string_t &method) override
-    {
-        m_method = method;
-    }
+    virtual void set_method(const utility::string_t &method) override;
 
-    virtual void set_user_agent(const utility::string_t &user_agent_string) override
-    {
-        m_user_agent_string = user_agent_string;
-    }
+    virtual void set_user_agent(const utility::string_t &user_agent_string) override;
 
-    virtual pplx::task<web_response> get_response() override
-    {
-        return pplx::task_from_result<web_response>(
-            web_response{ m_status_code, m_reason_phrase, pplx::task_from_result<utility::string_t>(m_response_body) });
-    }
+    virtual pplx::task<web_response> get_response() override;
 };

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -2,68 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #include "stdafx.h"
+#include "test_websocket_client.h"
 #include "websocket_transport.h"
 
 using namespace signalr;
 using namespace web::experimental;
-
-class test_websocket_client
-{
-public:
-
-    pplx::task<void> connect(const web::uri &url)
-    {
-        return m_connect_function(url);
-    }
-
-    pplx::task<void> send(web_sockets::client::websocket_outgoing_message msg)
-    {
-        return m_send_function(msg);
-    }
-
-    pplx::task<web_sockets::client::websocket_incoming_message> receive()
-    {
-        return m_receive_function();
-    }
-
-    pplx::task<void> close()
-    {
-        return m_close_function();
-    }
-
-    void set_connect_function(std::function<pplx::task<void>(const web::uri &url)> connect_function)
-    {
-        m_connect_function = connect_function;
-    }
-
-    void set_send_function(std::function<pplx::task<void>(web_sockets::client::websocket_outgoing_message)> send_function)
-    {
-        m_send_function = send_function;
-    }
-
-    void set_receive_function(std::function<pplx::task<web_sockets::client::websocket_incoming_message>()> receive_function)
-    {
-        m_receive_function = receive_function;
-    }
-
-    void set_close_function(std::function<pplx::task<void>()> close_function)
-    {
-        m_close_function = close_function;
-    }
-
-private:
-    std::function<pplx::task<void>(const web::uri &url)> m_connect_function
-        = [](const web::uri &){ return pplx::task_from_result(); };
-
-    std::function<pplx::task<void>(web_sockets::client::websocket_outgoing_message)> m_send_function
-        = [](web_sockets::client::websocket_outgoing_message msg){ return pplx::task_from_result(); };
-
-    std::function<pplx::task<web_sockets::client::websocket_incoming_message>()> m_receive_function
-        = [](){ return pplx::task_from_result(web_sockets::client::websocket_incoming_message()); };
-
-    std::function<pplx::task<void>()> m_close_function
-        = [](){ return pplx::task_from_result(); };
-};
 
 TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
 {


### PR DESCRIPTION
- moving url and querystring from connection to connection_impl
- marking ctors with 1 mandatory parameter as explicit to prevent from implicit conversions
- moving implementations from headers to cpp files

No functional changes
