### PR TITLE
SignalrNativeClientAndTheTemplateOfDoom - untemplating websocket_transport

### DIFF
--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj
@@ -101,12 +101,14 @@
     <ClInclude Include="..\..\..\..\include\signalrclient\_exports.h" />
     <ClInclude Include="..\..\connection_impl.h" />
     <ClInclude Include="..\..\constants.h" />
+    <ClInclude Include="..\..\default_websocket_client.h" />
     <ClInclude Include="..\..\http_sender.h" />
     <ClInclude Include="..\..\negotiation_response.h" />
     <ClInclude Include="..\..\request_sender.h" />
     <ClInclude Include="..\..\stdafx.h" />
     <ClInclude Include="..\..\targetver.h" />
     <ClInclude Include="..\..\url_builder.h" />
+    <ClInclude Include="..\..\websocket_client.h" />
     <ClInclude Include="..\..\websocket_transport.h" />
   </ItemGroup>
   <ItemGroup>
@@ -120,6 +122,8 @@
     </ClCompile>
     <ClCompile Include="..\..\transport_factory.cpp" />
     <ClCompile Include="..\..\url_builder.cpp" />
+    <ClCompile Include="..\..\default_websocket_client.cpp" />
+    <ClCompile Include="..\..\websocket_transport.cpp" />
     <ClCompile Include="..\..\web_request.cpp" />
     <ClCompile Include="..\..\web_request_factory.cpp" />
   </ItemGroup>

--- a/src/signalrclient/Build/VS2013/signalrclient.vcxproj.filters
+++ b/src/signalrclient/Build/VS2013/signalrclient.vcxproj.filters
@@ -75,6 +75,12 @@
     <ClInclude Include="..\..\..\..\include\signalrclient\connection_state.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\websocket_client.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\default_websocket_client.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\stdafx.cpp">
@@ -102,6 +108,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\web_request_factory.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\default_websocket_client.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\websocket_transport.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/signalrclient/default_websocket_client.cpp
+++ b/src/signalrclient/default_websocket_client.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "default_websocket_client.h"
+
+namespace signalr
+{
+    pplx::task<void> default_websocket_client::connect(const web::uri &url)
+    {
+        return m_underlying_client.connect(url);
+    }
+
+    pplx::task<void> default_websocket_client::send(const utility::string_t &message)
+    {
+        web_sockets::client::websocket_outgoing_message msg;
+        msg.set_utf8_message(utility::conversions::to_utf8string(message));
+        return m_underlying_client.send(msg);
+    }
+
+    pplx::task<std::string> default_websocket_client::receive()
+    {
+        return m_underlying_client.receive()
+            .then([](web_sockets::client::websocket_incoming_message msg)
+            {
+                return msg.extract_string();
+            });
+    }
+
+    pplx::task<void> default_websocket_client::close()
+    {
+        return m_underlying_client.close();
+    }
+}

--- a/src/signalrclient/default_websocket_client.h
+++ b/src/signalrclient/default_websocket_client.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include <cpprest\ws_client.h>
+#include "websocket_client.h"
+
+using namespace web::experimental;
+
+namespace signalr
+{
+    class default_websocket_client : public websocket_client
+    {
+    public:
+        pplx::task<void> connect(const web::uri &url) override;
+
+        pplx::task<void> send(const utility::string_t &message) override;
+
+        pplx::task<std::string> receive() override;
+
+        pplx::task<void> close() override;
+
+    private:
+        web_sockets::client::websocket_client m_underlying_client;
+    };
+}

--- a/src/signalrclient/transport_factory.cpp
+++ b/src/signalrclient/transport_factory.cpp
@@ -11,7 +11,7 @@ namespace signalr
     {
         if (transport_type == transport_type::websockets)
         {
-            return std::make_unique<websocket_transport<>>();
+            return std::make_unique<websocket_transport>(std::make_unique<default_websocket_client>());
         }
 
         throw std::exception("not implemented");

--- a/src/signalrclient/websocket_client.h
+++ b/src/signalrclient/websocket_client.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#pragma once
+
+#include <ppl.h>
+#include <cpprest\base_uri.h>
+
+namespace pplx = concurrency;
+
+namespace signalr
+{
+    class websocket_client
+    {
+    public:
+        virtual pplx::task<void> connect(const web::uri &url) = 0;
+
+        virtual pplx::task<void> send(const utility::string_t &message) = 0;
+
+        virtual pplx::task<std::string> receive() = 0;
+
+        virtual pplx::task<void> close() = 0;
+
+        virtual ~websocket_client() {};
+    };
+}

--- a/src/signalrclient/websocket_transport.cpp
+++ b/src/signalrclient/websocket_transport.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "websocket_transport.h"
+
+namespace signalr
+{
+    websocket_transport::websocket_transport(std::unique_ptr<websocket_client> websocket_client)
+        : m_websocket_client(std::move(websocket_client))
+    {}
+
+    pplx::task<void> websocket_transport::connect(const web::uri &url) 
+    {
+        // TODO: prepare request (websocket_client_config)
+
+        m_websocket_client->connect(url)
+            .then([this](pplx::task<void> connect_task){
+            try
+            {
+                connect_task.wait();
+                receive_loop();
+                this->m_connect_tce.set();
+            }
+            catch (const std::exception &e)
+            {
+                this->m_connect_tce.set_exception(e);
+            }
+        });
+
+        return pplx::create_task(m_connect_tce);
+    }
+
+    pplx::task<void> websocket_transport::send(const utility::string_t &data)
+    {
+        // send will throw if client not connected
+        return m_websocket_client->send(data);
+    }
+
+    pplx::task<void> websocket_transport::disconnect()
+    {
+        return m_websocket_client->close();
+    }
+
+
+    void websocket_transport::receive_loop()
+    {
+        // TODO: there is a race where m_websocket_client is destroyed in the destructor
+        // but the receive loop is not yet stopped since it is running on a different thread
+        // in which case we crash when try calling m_websocket_client->receive()
+        m_websocket_client->receive().then([this](pplx::task<std::string> receive_task)
+        {
+            try
+            {
+                auto msg_body = receive_task.get();
+                receive_loop();
+            }
+            catch (web_sockets::client::websocket_exception &)
+            {
+                // TODO: should close the websocket?
+                // TODO: report error
+            }
+            catch (std::exception &)
+            {
+                // TODO: should close the websocket?
+                // TODO: report error
+            }
+        });
+    }
+}

--- a/src/signalrclient/websocket_transport.h
+++ b/src/signalrclient/websocket_transport.h
@@ -6,93 +6,31 @@
 #include <cpprest\ws_client.h>
 #include "url_builder.h"
 #include "signalrclient\transport.h"
-
-using namespace web::experimental;
+#include "default_websocket_client.h"
 
 namespace signalr
 {
-    template<typename T = web_sockets::client::websocket_client> // testing
     class websocket_transport : public transport
     {
     public:
-        explicit websocket_transport() : websocket_transport(T())
-        { }
 
-        explicit websocket_transport(T&& websocket_client)
-            : m_websocket_client(std::move(websocket_client))
-        { }
+        websocket_transport(std::unique_ptr<websocket_client> websocket_client);
 
-        explicit websocket_transport(const T &websocket_client)
-            : m_websocket_client(websocket_client)
-        { }
+        websocket_transport(const websocket_transport&) = delete;
 
-        websocket_transport(const websocket_transport<T>&) = delete;
+        websocket_transport& operator=(const websocket_transport&) = delete;
 
-        websocket_transport<T>& operator=(const websocket_transport<T>&) = delete;
+        pplx::task<void> connect(const web::uri &url) override;
 
-        pplx::task<void> connect(const web::uri &url) override
-        {
-            // TODO: prepare request (websocket_client_config)
+        pplx::task<void> send(const utility::string_t &data) override;
 
-            m_websocket_client.connect(url)
-                .then([this](pplx::task<void> connect_task){
-                try
-                {
-                    connect_task.wait();
-                    receive_loop();
-                    this->m_connect_tce.set();
-                }
-                catch (const std::exception &e)
-                {
-                    this->m_connect_tce.set_exception(e);
-                }
-            });
-
-            return pplx::create_task(m_connect_tce);
-        }
-
-        pplx::task<void> send(const utility::string_t &data) override
-        {
-            web_sockets::client::websocket_outgoing_message msg;
-            msg.set_utf8_message(utility::conversions::to_utf8string(data));
-
-            // send will throw if client not connected
-            return m_websocket_client.send(msg);
-        }
-
-        pplx::task<void> disconnect() override
-        {
-            return m_websocket_client.close();
-        }
+        pplx::task<void> disconnect() override;
 
     private:
-        T m_websocket_client;
+        std::unique_ptr<websocket_client> m_websocket_client;
 
         pplx::task_completion_event<void> m_connect_tce;
 
-        void receive_loop()
-        {
-            m_websocket_client.receive().then([this](pplx::task<web_sockets::client::websocket_incoming_message> msg_task)
-            {
-                try
-                {
-                    auto msg = msg_task.get();
-                    msg.extract_string().then([this](std::string msg_body)
-                    {
-                        receive_loop();
-                    });
-                }
-                catch (web_sockets::client::websocket_exception &)
-                {
-                    // TODO: should close the websocket?
-                    // TODO: report error
-                }
-                catch (std::exception &)
-                {
-                    // TODO: should close the websocket?
-                    // TODO: report error
-                }
-            });
-        }
+        void receive_loop();
     };
 }

--- a/test/signalrclienttests/test_websocket_client.cpp
+++ b/test/signalrclienttests/test_websocket_client.cpp
@@ -6,8 +6,8 @@
 
 test_websocket_client::test_websocket_client() 
     : m_connect_function([](const web::uri &){ return pplx::task_from_result(); }),
-    m_send_function ([](web_sockets::client::websocket_outgoing_message msg){ return pplx::task_from_result(); }),
-    m_receive_function([](){ return pplx::task_from_result(web_sockets::client::websocket_incoming_message()); }),
+    m_send_function ([](const utility::string_t msg){ return pplx::task_from_result(); }),
+    m_receive_function([](){ return pplx::task_from_result<std::string>(""); }),
     m_close_function([](){ return pplx::task_from_result(); })
 
 { }
@@ -17,12 +17,12 @@ pplx::task<void> test_websocket_client::connect(const web::uri &url)
     return m_connect_function(url);
 }
 
-pplx::task<void> test_websocket_client::send(web_sockets::client::websocket_outgoing_message msg)
+pplx::task<void> test_websocket_client::send(const utility::string_t &msg)
 {
     return m_send_function(msg);
 }
 
-pplx::task<web_sockets::client::websocket_incoming_message> test_websocket_client::receive()
+pplx::task<std::string> test_websocket_client::receive()
 {
     return m_receive_function();
 }
@@ -37,12 +37,12 @@ void test_websocket_client::set_connect_function(std::function<pplx::task<void>(
     m_connect_function = connect_function;
 }
 
-void test_websocket_client::set_send_function(std::function<pplx::task<void>(web_sockets::client::websocket_outgoing_message)> send_function)
+void test_websocket_client::set_send_function(std::function<pplx::task<void>(const utility::string_t &msg)> send_function)
 {
     m_send_function = send_function;
 }
 
-void test_websocket_client::set_receive_function(std::function<pplx::task<web_sockets::client::websocket_incoming_message>()> receive_function)
+void test_websocket_client::set_receive_function(std::function<pplx::task<std::string>()> receive_function)
 {
     m_receive_function = receive_function;
 }

--- a/test/signalrclienttests/test_websocket_client.h
+++ b/test/signalrclienttests/test_websocket_client.h
@@ -4,37 +4,37 @@
 #pragma once
 
 #include <functional>
-#include <cpprest\ws_client.h>
+#include "websocket_client.h"
 
-using namespace web::experimental;
+using namespace signalr;
 
-class test_websocket_client
+class test_websocket_client : public websocket_client
 {
 public:
     test_websocket_client();
 
-    pplx::task<void> connect(const web::uri &url);
+    pplx::task<void> connect(const web::uri &url) override;
 
-    pplx::task<void> send(web_sockets::client::websocket_outgoing_message msg);
+    pplx::task<void> send(const utility::string_t& msg) override;
 
-    pplx::task<web_sockets::client::websocket_incoming_message> receive();
+    pplx::task<std::string> receive() override;
 
-    pplx::task<void> close();
+    pplx::task<void> close() override;
 
     void set_connect_function(std::function<pplx::task<void>(const web::uri &url)> connect_function);
 
-    void set_send_function(std::function<pplx::task<void>(web_sockets::client::websocket_outgoing_message)> send_function);
+    void set_send_function(std::function<pplx::task<void>(const utility::string_t& msg)> send_function);
 
-    void set_receive_function(std::function<pplx::task<web_sockets::client::websocket_incoming_message>()> receive_function);
+    void set_receive_function(std::function<pplx::task<std::string>()> receive_function);
 
     void set_close_function(std::function<pplx::task<void>()> close_function);
 
 private:
     std::function<pplx::task<void>(const web::uri &url)> m_connect_function;
 
-    std::function<pplx::task<void>(web_sockets::client::websocket_outgoing_message)> m_send_function;
+    std::function<pplx::task<void>(const utility::string_t&)> m_send_function;
 
-    std::function<pplx::task<web_sockets::client::websocket_incoming_message>()> m_receive_function;
+    std::function<pplx::task<std::string>()> m_receive_function;
 
     std::function<pplx::task<void>()> m_close_function;
 };

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -12,20 +12,26 @@ TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
 {
     bool connect_called = false, receive_called = false;
 
-    test_websocket_client client;
-    client.set_connect_function([&connect_called](const web::uri &) -> pplx::task<void>
+    auto client = std::make_unique<test_websocket_client>();
+
+    client->set_connect_function([&connect_called](const web::uri &) -> pplx::task<void>
     {
         connect_called = true;
         return pplx::task_from_result();
     });
 
-    client.set_receive_function([&receive_called]() -> pplx::task<web_sockets::client::websocket_incoming_message>
+
+    pplx::task_completion_event<std::string> receive_tce;
+
+    client->set_receive_function([&receive_called, &receive_tce]()->pplx::task<std::string>
     {
         receive_called = true;
-        return pplx::task_from_result(web_sockets::client::websocket_incoming_message());
+
+        // TODO: a workaround for a race in the receive_loop - breaks the loop
+        return pplx::task_from_exception<std::string>(std::exception());
     });
 
-    websocket_transport<test_websocket_client> ws_transport(client);
+    websocket_transport ws_transport(std::move(client));
 
     ws_transport.connect(_XPLATSTR("http://fakeuri.org")).wait();
 
@@ -35,13 +41,13 @@ TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
 
 TEST(websocket_transport_connect, connect_propagates_exceptions)
 {
-    test_websocket_client client;
-    client.set_connect_function([](const web::uri &) -> pplx::task<void>
+    auto client = std::make_unique<test_websocket_client>();
+    client->set_connect_function([](const web::uri &) -> pplx::task<void>
     {
         throw web_sockets::client::websocket_exception(_XPLATSTR("connecting failed"));
     });
 
-    websocket_transport<test_websocket_client> ws_transport(client);
+    websocket_transport ws_transport(std::move(client));
 
     try
     {
@@ -58,14 +64,15 @@ TEST(websocket_transport_send, send_creates_and_sends_websocket_messages)
 {
     bool send_called = false;
 
-    test_websocket_client client;
-    client.set_send_function([&send_called](web_sockets::client::websocket_outgoing_message msg) -> pplx::task<void>
+    auto client = std::make_unique<test_websocket_client>();
+
+    client->set_send_function([&send_called](const utility::string_t&) -> pplx::task<void>
     {
         send_called = true;
         return pplx::task_from_result();
     });
 
-    websocket_transport<test_websocket_client> ws_transport(client);
+    websocket_transport ws_transport(std::move(client));
 
     ws_transport.send(_XPLATSTR("ABC")).wait();
 
@@ -76,14 +83,15 @@ TEST(websocket_transport_disconnect, disconnect_closes_websocket)
 {
     bool close_called = false;
 
-    test_websocket_client client;
-    client.set_close_function([&close_called]() -> pplx::task<void>
+    auto client = std::make_unique<test_websocket_client>();
+
+    client->set_close_function([&close_called]() -> pplx::task<void>
     {
         close_called = true;
         return pplx::task_from_result();
     });
 
-    websocket_transport<test_websocket_client> ws_transport(client);
+    websocket_transport ws_transport(std::move(client));
 
     ws_transport.disconnect().wait();
 


### PR DESCRIPTION
casablanca websocket_client returns websocket_incoming_message. However because there is no way to set the websocket_incoming_message response contents externally testing scenarios where messages were received was not possible. To make the code testable we would have to change the template type to something that returns pplx::taskutility::string_t instead of pplx::task<websocket_incoming_message> which meant we could not use the casablanca websocket_client directly as the template type which was the main point of using the template in the first place. As a result the static polymorphism (i.e. template) is being replaced with runtime polymorphism (base pure virtual class).
