### PR TITLE
IntroducingErrors - adding trace_level::errors value

### DIFF
--- a/include/signalrclient/trace_level.h
+++ b/include/signalrclient/trace_level.h
@@ -11,7 +11,8 @@ namespace signalr
         messages = 1,
         events = 2,
         state_changes = 4,
-        all = messages | events | state_changes
+        errors = 8,
+        all = messages | events | state_changes | errors
     };
 
     inline trace_level operator|(trace_level lhs, trace_level rhs)

--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -54,7 +54,7 @@ namespace signalr
                 catch (const std::exception &e)
                 {
                     connection->get_logger().log(
-                        trace_level::messages,
+                        trace_level::errors,
                         utility::string_t(_XPLATSTR("connection could not be started due to: "))
                             .append(utility::conversions::to_string_t(e.what())));
 
@@ -84,8 +84,7 @@ namespace signalr
         {
             m_logger.log(
                 trace_level::state_changes,
-                utility::string_t(_XPLATSTR("state changed: "))
-                .append(translate_connection_state(old_state))
+                translate_connection_state(old_state)
                 .append(_XPLATSTR(" -> "))
                 .append(translate_connection_state(new_state)));
 

--- a/src/signalrclient/connection_impl.h
+++ b/src/signalrclient/connection_impl.h
@@ -50,6 +50,6 @@ namespace signalr
             std::unique_ptr<web_request_factory> web_request_factory, std::unique_ptr<transport_factory> transport_factory);
 
         bool change_state(connection_state old_state, connection_state new_state);
-        utility::string_t translate_connection_state(connection_state state);
+        static utility::string_t translate_connection_state(connection_state state);
     };
 }

--- a/src/signalrclient/logger.cpp
+++ b/src/signalrclient/logger.cpp
@@ -4,7 +4,7 @@
 #include "stdafx.h"
 #include "logger.h"
 #include <cpprest\asyncrt_utils.h>
-
+#include <iomanip>
 
 namespace signalr
 {
@@ -19,7 +19,8 @@ namespace signalr
             try
             {
                 utility::ostringstream_t os;
-                os << utility::datetime::utc_now().to_string(utility::datetime::date_format::ISO_8601) << _XPLATSTR(" ") << entry << std::endl;
+                os << utility::datetime::utc_now().to_string(utility::datetime::date_format::ISO_8601) << _XPLATSTR(" [")
+                    << std::left << std::setw(12) << translate_trace_level(level) << "] "<< entry << std::endl;
                 m_log_writer->write(os.str());
             }
             catch (const std::exception &e)
@@ -31,6 +32,24 @@ namespace signalr
             {
                 ucerr << _XPLATSTR("unknown error occurred when logging") << std::endl << _XPLATSTR("    entry: ") << entry << std::endl;
             }
+        }
+    }
+
+    utility::string_t logger::translate_trace_level(trace_level trace_level)
+    {
+        switch (trace_level)
+        {
+        case trace_level::messages:
+            return _XPLATSTR("message");
+        case trace_level::state_changes:
+            return _XPLATSTR("state change");
+        case trace_level::events:
+            return _XPLATSTR("event");
+        case trace_level::errors:
+            return _XPLATSTR("error");
+        default:
+            _ASSERTE(false);
+            return _XPLATSTR("(unknown)");
         }
     }
 }

--- a/src/signalrclient/logger.h
+++ b/src/signalrclient/logger.h
@@ -19,5 +19,7 @@ namespace signalr
     private:
         std::shared_ptr<log_writer> m_log_writer;
         trace_level m_trace_level;
+
+        static utility::string_t translate_trace_level(trace_level trace_level);
     };
 }

--- a/src/signalrclient/websocket_transport.cpp
+++ b/src/signalrclient/websocket_transport.cpp
@@ -56,7 +56,7 @@ namespace signalr
             catch (const std::exception &e)
             {
                 connection->get_logger().log(
-                    trace_level::messages,
+                    trace_level::errors,
                     utility::string_t(_XPLATSTR("[websocket transport] exception when connecting to the server: "))
                         .append(utility::conversions::to_string_t(e.what())));
 
@@ -93,7 +93,7 @@ namespace signalr
                 catch (const std::exception &e)
                 {
                     logger.log(
-                        trace_level::messages,
+                        trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] exception when closing websocket: "))
                         .append(utility::conversions::to_string_t(e.what())));
                 }
@@ -129,28 +129,28 @@ namespace signalr
                 catch (const web_sockets::client::websocket_exception& e)
                 {
                     connection->get_logger().log(
-                        trace_level::messages,
+                        trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] websocket exception when receiving data: "))
                         .append(utility::conversions::to_string_t(e.what())));
                 }
                 catch (const pplx::task_canceled& e)
                 {
                     connection->get_logger().log(
-                        trace_level::messages,
+                        trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] receive task cancelled: "))
                         .append(utility::conversions::to_string_t(e.what())));
                 }
                 catch (const std::exception& e)
                 {
                     connection->get_logger().log(
-                        trace_level::messages,
+                        trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] error receiving response from websocket: "))
                         .append(utility::conversions::to_string_t(e.what())));
                 }
                 catch (...)
                 {
                     connection->get_logger().log(
-                        trace_level::messages,
+                        trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] unknown error occurred when receiving response from websocket")));
                 }
 

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -124,7 +124,7 @@ TEST(connection_impl_start, start_logs_exceptions)
     });
 
     auto connection =
-        connection_impl::create(_XPLATSTR("url"), _XPLATSTR(""), trace_level::messages, writer,
+        connection_impl::create(_XPLATSTR("url"), _XPLATSTR(""), trace_level::errors, writer,
             std::move(web_request_factory), std::make_unique<transport_factory>());
 
     try
@@ -138,7 +138,7 @@ TEST(connection_impl_start, start_logs_exceptions)
     ASSERT_FALSE(log_entries.empty());
 
     auto entry = remove_date_from_log_entry(log_entries[0]);
-    ASSERT_EQ(_XPLATSTR("connection could not be started due to: web exception - 404 Bad request\n"), entry);
+    ASSERT_EQ(_XPLATSTR("[error       ] connection could not be started due to: web exception - 404 Bad request\n"), entry);
 }
 
 TEST(connection_impl_start, start_propagates_exceptions_from_negotiate)
@@ -186,5 +186,5 @@ TEST(connection_impl_change_state, change_state_logs)
     ASSERT_FALSE(log_entries.empty());
 
     auto entry = remove_date_from_log_entry(log_entries[0]);
-    ASSERT_EQ(_XPLATSTR("state changed: disconnected -> connecting\n"), entry);
+    ASSERT_EQ(_XPLATSTR("[state change] disconnected -> connecting\n"), entry);
 }

--- a/test/signalrclienttests/logger_tests.cpp
+++ b/test/signalrclienttests/logger_tests.cpp
@@ -37,14 +37,15 @@ TEST(logger_write, entries_added_for_combined_trace_level)
 {
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    logger l(writer, trace_level::messages | trace_level::state_changes | trace_level::events);
+    logger l(writer, trace_level::messages | trace_level::state_changes | trace_level::events | trace_level::errors);
     l.log(trace_level::messages, _XPLATSTR("message"));
     l.log(trace_level::events, _XPLATSTR("event"));
     l.log(trace_level::state_changes, _XPLATSTR("state_change"));
+    l.log(trace_level::errors, _XPLATSTR("error"));
 
     auto log_entries = std::dynamic_pointer_cast<memory_log_writer>(writer)->get_log_entries();
 
-    ASSERT_EQ(3, log_entries.size());
+    ASSERT_EQ(4, log_entries.size());
 }
 
 TEST(logger_write, entries_formatted_correctly)
@@ -63,5 +64,5 @@ TEST(logger_write, entries_formatted_correctly)
     auto date = utility::datetime::from_string(date_str, utility::datetime::ISO_8601);
     ASSERT_EQ(date_str, date.to_string(utility::datetime::ISO_8601));
 
-    ASSERT_EQ(_XPLATSTR("message\n"), remove_date_from_log_entry(entry));
+    ASSERT_EQ(_XPLATSTR("[message     ] message\n"), remove_date_from_log_entry(entry));
 }

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -71,7 +71,7 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
     websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::messages, writer) };
+        _XPLATSTR(""), trace_level::errors, writer) };
 
     try
     {
@@ -87,7 +87,7 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
     auto entry = remove_date_from_log_entry(log_entries[0]);
 
     ASSERT_EQ(
-        _XPLATSTR("[websocket transport] exception when connecting to the server: connecting failed\n"),
+        _XPLATSTR("[error       ] [websocket transport] exception when connecting to the server: connecting failed\n"),
         entry);
 }
 
@@ -188,7 +188,7 @@ TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
     websocket_transport ws_transport{client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::messages, writer)};
+        _XPLATSTR(""), trace_level::errors, writer)};
 
     try
     {
@@ -204,7 +204,7 @@ TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
     auto entry = remove_date_from_log_entry(log_entries[0]);
 
     ASSERT_EQ(
-        _XPLATSTR("[websocket transport] exception when closing websocket: connection closing failed\n"),
+        _XPLATSTR("[error       ] [websocket transport] exception when closing websocket: connection closing failed\n"),
         entry);
 }
 
@@ -249,21 +249,21 @@ TEST(websocket_transport_receive_loop, receive_loop_logs_websocket_exceptions)
 {
     receive_loop_logs_exception_runner(
         web_sockets::client::websocket_exception(_XPLATSTR("receive failed")),
-        _XPLATSTR("[websocket transport] websocket exception when receiving data: receive failed\n"));
+        _XPLATSTR("[error       ] [websocket transport] websocket exception when receiving data: receive failed\n"));
 }
 
 TEST(websocket_transport_receive_loop, receive_loop_logs_if_receive_task_cancelled)
 {
     receive_loop_logs_exception_runner(
         pplx::task_canceled("cancelled"),
-        _XPLATSTR("[websocket transport] receive task cancelled: cancelled\n"));
+        _XPLATSTR("[error       ] [websocket transport] receive task cancelled: cancelled\n"));
 }
 
 TEST(websocket_transport_receive_loop, receive_loop_logs_std_exception)
 {
     receive_loop_logs_exception_runner(
         std::exception("exception"),
-        _XPLATSTR("[websocket transport] error receiving response from websocket: exception\n"));
+        _XPLATSTR("[error       ] [websocket transport] error receiving response from websocket: exception\n"));
 }
 
 template<class T>
@@ -281,7 +281,7 @@ void receive_loop_logs_exception_runner(const T& e, const utility::string_t& exp
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
     websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::messages, writer) };
+        _XPLATSTR(""), trace_level::errors, writer) };
 
     ws_transport.connect(_XPLATSTR("url"))
         .then([&receive_event]()


### PR DESCRIPTION
Adding an additional class of log message for errors. Changing current log messages to errors where applicable. Qualifying log entries with the class the message belongs to.
