### PR TITLE
Robin->Hood - enforcing the websocket_transport to be used as a pointer

### DIFF
--- a/src/signalrclient/transport_factory.cpp
+++ b/src/signalrclient/transport_factory.cpp
@@ -8,11 +8,11 @@
 
 namespace signalr
 {
-    std::unique_ptr<transport> transport_factory::create_transport(transport_type transport_type, std::shared_ptr<connection_impl> connection)
+    std::shared_ptr<transport> transport_factory::create_transport(transport_type transport_type, std::shared_ptr<connection_impl> connection)
     {
         if (transport_type == transport_type::websockets)
         {
-            return std::make_unique<websocket_transport>(std::make_unique<default_websocket_client>(), connection);
+            return websocket_transport::create(std::make_shared<default_websocket_client>(), connection);
         }
 
         throw std::exception("not implemented");

--- a/src/signalrclient/transport_factory.h
+++ b/src/signalrclient/transport_factory.h
@@ -14,7 +14,7 @@ namespace signalr
     class transport_factory
     {
     public:
-        virtual std::unique_ptr<transport> create_transport(transport_type transport_type, std::shared_ptr<connection_impl> connection);
+        virtual std::shared_ptr<transport> create_transport(transport_type transport_type, std::shared_ptr<connection_impl> connection);
 
         virtual ~transport_factory();
     };

--- a/src/signalrclient/websocket_transport.cpp
+++ b/src/signalrclient/websocket_transport.cpp
@@ -7,9 +7,9 @@
 
 namespace signalr
 {
-    namespace
+    std::shared_ptr<transport> websocket_transport::create(std::shared_ptr<websocket_client> websocket_client, std::shared_ptr<connection_impl> connection)
     {
-        void receive_loop(std::shared_ptr<websocket_client> websocket_client, std::shared_ptr<connection_impl> connection, pplx::cancellation_token_source cts);
+        return std::shared_ptr<transport>(new websocket_transport(websocket_client, connection));
     }
 
     websocket_transport::websocket_transport(std::shared_ptr<websocket_client> websocket_client, std::shared_ptr<connection_impl> connection)
@@ -40,22 +40,22 @@ namespace signalr
 
         // TODO: prepare request (websocket_client_config)
         pplx::cancellation_token_source receive_loop_cts;
-        std::shared_ptr<websocket_client> websocket_client(m_websocket_client);
         pplx::task_completion_event<void> connect_tce;
-        auto connection = m_connection;
+
+        auto transport = shared_from_this();
 
         m_websocket_client->connect(url)
-            .then([websocket_client, connect_tce, receive_loop_cts, connection](pplx::task<void> connect_task)
+            .then([transport, connect_tce, receive_loop_cts](pplx::task<void> connect_task)
         {
             try
             {
                 connect_task.get();
-                receive_loop(websocket_client, connection, receive_loop_cts);
+                transport->receive_loop(receive_loop_cts);
                 connect_tce.set();
             }
             catch (const std::exception &e)
             {
-                connection->get_logger().log(
+                transport->m_connection->get_logger().log(
                     trace_level::errors,
                     utility::string_t(_XPLATSTR("[websocket transport] exception when connecting to the server: "))
                         .append(utility::conversions::to_string_t(e.what())));
@@ -100,17 +100,25 @@ namespace signalr
             });
     }
 
-    // unnamed namespace makes this function invisible/unusable in other translation units
-    namespace
+    void websocket_transport::receive_loop(pplx::cancellation_token_source cts)
     {
-        void receive_loop(std::shared_ptr<websocket_client> websocket_client, std::shared_ptr<connection_impl> connection, pplx::cancellation_token_source cts)
+        auto this_transport = shared_from_this();
+
+        // Passing the `std::weak_ptr<websocket_transport>` prevents from a memory leak where we would capture the shared_ptr to
+        // the transport in the continuation lambda and as a result as long as the loop runs the ref count would never get to
+        // zero. Now we capture the weak pointer and get the shared pointer only when the continuation runs so the ref count is
+        // incremented when the shared pointer is acquired and then decremented when it goes out of scope of the continuation.
+        auto weak_transport = std::weak_ptr<websocket_transport>(this_transport);
+
+        this_transport->m_websocket_client->receive()
+            // There are two cases when we exit the loop. The first case is implicit - we pass the cancellation_token
+            // to `then` (note this is after the lambda body) and if the token is cancelled the continuation will not
+            // run at all. The second - explicit - case happens if the token gets cancelled after the continuation has
+            // been started in which case we just stop the loop by not scheduling another receive task.
+            .then([weak_transport, cts](pplx::task<std::string> receive_task)
         {
-            websocket_client->receive()
-                // There are two cases when we exit the loop. The first case is implicit - we pass the cancellation_token
-                // to `then` (note this is after the lambda body) and if the token is cancelled the continuation will not
-                // run at all. The second - explicit - case happens if the token gets cancelled after the continuation has
-                // been started in which case we just stop the loop by not scheduling another receive task.
-                .then([websocket_client, connection, cts](pplx::task<std::string> receive_task)
+            auto transport = weak_transport.lock();
+            if (transport)
             {
                 try
                 {
@@ -120,7 +128,7 @@ namespace signalr
 
                     if (!pplx::is_task_cancellation_requested())
                     {
-                        receive_loop(websocket_client, connection, cts);
+                        transport->receive_loop(cts);
                     }
 
                     return;
@@ -128,34 +136,34 @@ namespace signalr
                 // TODO: report error, close websocket (when appropriate)
                 catch (const web_sockets::client::websocket_exception& e)
                 {
-                    connection->get_logger().log(
+                    transport->m_connection->get_logger().log(
                         trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] websocket exception when receiving data: "))
                         .append(utility::conversions::to_string_t(e.what())));
                 }
                 catch (const pplx::task_canceled& e)
                 {
-                    connection->get_logger().log(
+                    transport->m_connection->get_logger().log(
                         trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] receive task cancelled: "))
                         .append(utility::conversions::to_string_t(e.what())));
                 }
                 catch (const std::exception& e)
                 {
-                    connection->get_logger().log(
+                    transport->m_connection->get_logger().log(
                         trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] error receiving response from websocket: "))
                         .append(utility::conversions::to_string_t(e.what())));
                 }
                 catch (...)
                 {
-                    connection->get_logger().log(
+                    transport->m_connection->get_logger().log(
                         trace_level::errors,
                         utility::string_t(_XPLATSTR("[websocket transport] unknown error occurred when receiving response from websocket")));
                 }
+            }
 
-                cts.cancel();
-            }, cts.get_token());
-        }
+            cts.cancel();
+        }, cts.get_token());
     }
 }

--- a/src/signalrclient/websocket_transport.h
+++ b/src/signalrclient/websocket_transport.h
@@ -12,10 +12,10 @@
 
 namespace signalr
 {
-    class websocket_transport : public transport
+    class websocket_transport : public transport, public std::enable_shared_from_this<websocket_transport>
     {
     public:
-        websocket_transport(std::shared_ptr<websocket_client> websocket_client, std::shared_ptr<connection_impl> connection);
+        static std::shared_ptr<transport> create(std::shared_ptr<websocket_client> websocket_client, std::shared_ptr<connection_impl> connection);
 
         ~websocket_transport();
 
@@ -30,9 +30,13 @@ namespace signalr
         pplx::task<void> disconnect() override;
 
     private:
+        websocket_transport(std::shared_ptr<websocket_client> websocket_client, std::shared_ptr<connection_impl> connection);
+
         std::shared_ptr<websocket_client> m_websocket_client;
         std::shared_ptr<connection_impl> m_connection;
 
         pplx::cancellation_token_source m_receive_loop_cts;
+
+        void receive_loop(pplx::cancellation_token_source cts);
     };
 }

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -13,8 +13,8 @@ using namespace web::experimental;
 
 TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
 {
-    bool connect_called = false, receive_called = false;
-
+    auto connect_called = false;
+    auto receive_called = std::make_shared<bool>(false);
     auto client = std::make_shared<test_websocket_client>();
 
     client->set_connect_function([&connect_called](const web::uri &) -> pplx::task<void>
@@ -23,19 +23,19 @@ TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
         return pplx::task_from_result();
     });
 
-    client->set_receive_function([&receive_called]()->pplx::task<std::string>
+    client->set_receive_function([receive_called]()->pplx::task<std::string>
     {
-        receive_called = true;
+        *receive_called = true;
         return pplx::task_from_result(std::string(""));
     });
 
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"), _XPLATSTR(""),
-        trace_level::none, std::make_shared<trace_log_writer>()) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"), _XPLATSTR(""),
+        trace_level::none, std::make_shared<trace_log_writer>()));
 
-    ws_transport.connect(_XPLATSTR("http://fakeuri.org")).get();
+    ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
 
     ASSERT_TRUE(connect_called);
-    ASSERT_TRUE(receive_called);
+    ASSERT_TRUE(*receive_called);
 }
 
 TEST(websocket_transport_connect, connect_propagates_exceptions)
@@ -46,12 +46,12 @@ TEST(websocket_transport_connect, connect_propagates_exceptions)
         return pplx::task_from_exception<void>(web_sockets::client::websocket_exception(_XPLATSTR("connecting failed")));
     });
 
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()));
 
     try
     {
-        ws_transport.connect(_XPLATSTR("http://fakeuri.org")).get();
+        ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
         ASSERT_TRUE(false); // exception not thrown
     }
     catch (const std::exception &e)
@@ -70,12 +70,12 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::errors, writer) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::errors, writer));
 
     try
     {
-        ws_transport.connect(_XPLATSTR("http://fakeuri.org")).wait();
+        ws_transport->connect(_XPLATSTR("http://fakeuri.org")).wait();
     }
     catch (...)
     { }
@@ -94,14 +94,14 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
 TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_transport)
 {
     auto client = std::make_shared<test_websocket_client>();
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()));
 
-    ws_transport.connect(_XPLATSTR("http://fakeuri.org")).wait();
+    ws_transport->connect(_XPLATSTR("http://fakeuri.org")).wait();
 
     try
     {
-        ws_transport.connect(_XPLATSTR("http://fakeuri.org")).wait();
+        ws_transport->connect(_XPLATSTR("http://fakeuri.org")).wait();
         ASSERT_TRUE(false); // exception not thrown
     }
     catch (const std::exception &e)
@@ -112,15 +112,33 @@ TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_trans
 
 TEST(websocket_transport_connect, can_connect_after_disconnecting)
 {
-
     auto client = std::make_shared<test_websocket_client>();
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()));
 
-    ws_transport.connect(_XPLATSTR("http://fakeuri.org")).get();
-    ws_transport.disconnect().get();
-    ws_transport.connect(_XPLATSTR("http://fakeuri.org")).get();
+    ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
+    ws_transport->disconnect().get();
+    ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
     // shouldn't throw or crash
+}
+
+TEST(websocket_transport_connect, transport_destroyed_even_if_disconnect_not_called)
+{
+    auto client = std::make_shared<test_websocket_client>();
+    {
+        auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+            _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()));
+
+        ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
+    }
+
+    // TODO: once we have a timer we should replace this with a task
+    // that is being set to complete in `client.close()` or times out
+    pplx::wait(100);
+
+    // the idea is that if the transport is not destroyed it will hold a reference
+    // to the client and therefore the `use_count()` will be greater than 1
+    ASSERT_EQ(1, client.use_count());
 }
 
 TEST(websocket_transport_send, send_creates_and_sends_websocket_messages)
@@ -135,10 +153,10 @@ TEST(websocket_transport_send, send_creates_and_sends_websocket_messages)
         return pplx::task_from_result();
     });
 
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()));
 
-    ws_transport.send(_XPLATSTR("ABC")).wait();
+    ws_transport->send(_XPLATSTR("ABC")).wait();
 
     ASSERT_TRUE(send_called);
 }
@@ -155,10 +173,10 @@ TEST(websocket_transport_disconnect, disconnect_closes_websocket)
         return pplx::task_from_result();
     });
 
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()));
 
-    ws_transport.disconnect().get();
+    ws_transport->disconnect().get();
 
     ASSERT_TRUE(close_called);
 }
@@ -172,9 +190,9 @@ TEST(websocket_transport_disconnect, disconnect_does_not_throw)
         return pplx::task_from_exception<void>(std::exception());
     });
 
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()) };
-    ws_transport.disconnect().get();
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()));
+    ws_transport->disconnect().get();
 }
 
 TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
@@ -187,12 +205,12 @@ TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    websocket_transport ws_transport{client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::errors, writer)};
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::errors, writer));
 
     try
     {
-        ws_transport.disconnect().get();
+        ws_transport->disconnect().get();
     }
     catch (...)
     {}
@@ -229,15 +247,15 @@ TEST(websocket_transport_disconnect, receive_not_called_after_disconnect)
         return pplx::create_task(receive_task_tce);
     });
 
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()));
 
-    ws_transport.connect(_XPLATSTR("http://fakeuri.org")).get();
-    ws_transport.disconnect().get();
+    ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
+    ws_transport->disconnect().get();
 
     receive_task_tce = pplx::task_completion_event<std::string>();
-    ws_transport.connect(_XPLATSTR("http://fakeuri.org")).get();
-    ws_transport.disconnect().get();
+    ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
+    ws_transport->disconnect().get();
 
     ASSERT_EQ(2, num_called);
 }
@@ -280,10 +298,10 @@ void receive_loop_logs_exception_runner(const T& e, const utility::string_t& exp
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    websocket_transport ws_transport{ client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::errors, writer) };
+    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
+        _XPLATSTR(""), trace_level::errors, writer));
 
-    ws_transport.connect(_XPLATSTR("url"))
+    ws_transport->connect(_XPLATSTR("url"))
         .then([&receive_event]()
     {
         receive_event.wait();


### PR DESCRIPTION
I prototyped the 'connect' request and it seems that making the `receive_loop` a member of the `websocket_transport` would make it easier to invoke a callback when a message is received. If the mechanism is implemented in the `transport` type we could call it from each transport instead of implementing it in each transport. Because the `receive_loop` schedules itself in a task we need to pass `this` a `shared_ptr` which results in deriving the class from `std::enable_shared_from_this` which results in converting all the usages to `shared_ptr`'s to prevent from incorrect usages resulting in undefined behavior.
