### PR TITLE
DontBuyBreweryToDrinkAPint - removing reference to connection from trans...

### DIFF
--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -53,7 +53,7 @@ namespace signalr
                 }
                 catch (const std::exception &e)
                 {
-                    connection->get_logger().log(
+                    connection->m_logger.log(
                         trace_level::errors,
                         utility::string_t(_XPLATSTR("connection could not be started due to: "))
                             .append(utility::conversions::to_string_t(e.what())));
@@ -69,11 +69,6 @@ namespace signalr
     connection_state connection_impl::get_connection_state() const
     {
         return m_connection_state.load();
-    }
-
-    logger connection_impl::get_logger() const
-    {
-        return m_logger;
     }
 
     bool connection_impl::change_state(connection_state old_state, connection_state new_state)

--- a/src/signalrclient/connection_impl.h
+++ b/src/signalrclient/connection_impl.h
@@ -35,8 +35,6 @@ namespace signalr
 
         connection_state get_connection_state() const;
 
-        logger get_logger() const;
-
     private:
         web::uri m_base_url;
         utility::string_t m_query_string;

--- a/src/signalrclient/transport.cpp
+++ b/src/signalrclient/transport.cpp
@@ -7,8 +7,8 @@
 
 namespace signalr
 {
-    transport::transport(std::shared_ptr<connection_impl> connection, std::function<void(const utility::string_t&)> process_response_callback)
-        : m_connection(connection), m_process_response_callback(process_response_callback)
+    transport::transport(logger logger, std::function<void(const utility::string_t&)> process_response_callback)
+        : m_logger(logger), m_process_response_callback(process_response_callback)
     {}
 
     // Do NOT remove this destructor. Letting the compiler generate and inline the default dtor may lead to

--- a/src/signalrclient/transport.h
+++ b/src/signalrclient/transport.h
@@ -5,6 +5,7 @@
 
 #include <cpprest\base_uri.h>
 #include <ppl.h>
+#include "logger.h"
 
 namespace pplx = Concurrency;
 
@@ -24,11 +25,11 @@ namespace signalr
         virtual ~transport();
 
     protected:
-        transport(std::shared_ptr<connection_impl> connection, std::function<void(const utility::string_t &)> process_response_callback);
+        transport(logger logger, std::function<void(const utility::string_t &)> process_response_callback);
 
         void process_response(const utility::string_t &message);
 
-        std::shared_ptr<connection_impl> m_connection;
+        logger m_logger;
 
     private:
         std::function<void(const utility::string_t &)> m_process_response_callback;

--- a/src/signalrclient/transport_factory.cpp
+++ b/src/signalrclient/transport_factory.cpp
@@ -4,17 +4,16 @@
 #include "stdafx.h"
 #include "transport_factory.h"
 #include "websocket_transport.h"
-#include "connection_impl.h"
 
 namespace signalr
 {
     std::shared_ptr<transport> transport_factory::create_transport(transport_type transport_type,
-        std::shared_ptr<connection_impl> connection, std::function<void(utility::string_t)> process_response_callback)
+        logger logger, std::function<void(utility::string_t)> process_response_callback)
     {
         if (transport_type == transport_type::websockets)
         {
             return websocket_transport::create(
-                std::make_shared<default_websocket_client>(), connection, process_response_callback);
+                std::make_shared<default_websocket_client>(), logger, process_response_callback);
         }
 
         throw std::exception("not implemented");

--- a/src/signalrclient/transport_factory.h
+++ b/src/signalrclient/transport_factory.h
@@ -15,7 +15,7 @@ namespace signalr
     {
     public:
         virtual std::shared_ptr<transport> create_transport(transport_type transport_type,
-            std::shared_ptr<connection_impl> connection, std::function<void(utility::string_t)> process_response_callback);
+            logger logger, std::function<void(utility::string_t)> process_response_callback);
 
         virtual ~transport_factory();
     };

--- a/src/signalrclient/websocket_transport.h
+++ b/src/signalrclient/websocket_transport.h
@@ -16,7 +16,7 @@ namespace signalr
     {
     public:
         static std::shared_ptr<transport> create(std::shared_ptr<websocket_client> websocket_client,
-            std::shared_ptr<connection_impl> connection, std::function<void(const utility::string_t&)> process_response_callback);
+            logger logger, std::function<void(const utility::string_t&)> process_response_callback);
 
         ~websocket_transport();
 
@@ -31,8 +31,8 @@ namespace signalr
         pplx::task<void> disconnect() override;
 
     private:
-        websocket_transport(std::shared_ptr<websocket_client> websocket_client,
-            std::shared_ptr<connection_impl> connection, std::function<void(const utility::string_t &)> process_response_callback);
+        websocket_transport(std::shared_ptr<websocket_client> websocket_client, logger logger,
+            std::function<void(const utility::string_t &)> process_response_callback);
 
         std::shared_ptr<websocket_client> m_websocket_client;
 

--- a/test/signalrclienttests/websocket_transport_tests.cpp
+++ b/test/signalrclienttests/websocket_transport_tests.cpp
@@ -29,8 +29,8 @@ TEST(websocket_transport_connect, connect_connects_and_starts_receive_loop)
         return pplx::task_from_result(std::string(""));
     });
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"), _XPLATSTR(""),
-        trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){});
 
     ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
 
@@ -46,8 +46,8 @@ TEST(websocket_transport_connect, connect_propagates_exceptions)
         return pplx::task_from_exception<void>(web_sockets::client::websocket_exception(_XPLATSTR("connecting failed")));
     });
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){});
 
     try
     {
@@ -69,9 +69,7 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
     });
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
-
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::errors, writer), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(writer, trace_level::errors), [](const utility::string_t&){});
 
     try
     {
@@ -94,8 +92,8 @@ TEST(websocket_transport_connect, connect_logs_exceptions)
 TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_transport)
 {
     auto client = std::make_shared<test_websocket_client>();
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){});
 
     ws_transport->connect(_XPLATSTR("http://fakeuri.org")).wait();
 
@@ -113,8 +111,8 @@ TEST(websocket_transport_connect, cannot_call_connect_on_already_connected_trans
 TEST(websocket_transport_connect, can_connect_after_disconnecting)
 {
     auto client = std::make_shared<test_websocket_client>();
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){});
 
     ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
     ws_transport->disconnect().get();
@@ -126,8 +124,8 @@ TEST(websocket_transport_connect, transport_destroyed_even_if_disconnect_not_cal
 {
     auto client = std::make_shared<test_websocket_client>();
     {
-        auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-            _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+        auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+            [](const utility::string_t&){});
 
         ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
     }
@@ -153,8 +151,8 @@ TEST(websocket_transport_send, send_creates_and_sends_websocket_messages)
         return pplx::task_from_result();
     });
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){});
 
     ws_transport->send(_XPLATSTR("ABC")).wait();
 
@@ -173,8 +171,8 @@ TEST(websocket_transport_disconnect, disconnect_closes_websocket)
         return pplx::task_from_result();
     });
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){});
 
     ws_transport->disconnect().get();
 
@@ -190,8 +188,9 @@ TEST(websocket_transport_disconnect, disconnect_does_not_throw)
         return pplx::task_from_exception<void>(std::exception());
     });
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){});
+
     ws_transport->disconnect().get();
 }
 
@@ -205,8 +204,7 @@ TEST(websocket_transport_disconnect, disconnect_logs_exceptions)
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::errors, writer), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(writer, trace_level::errors), [](const utility::string_t&){});
 
     try
     {
@@ -247,8 +245,8 @@ TEST(websocket_transport_disconnect, receive_not_called_after_disconnect)
         return pplx::create_task(receive_task_tce);
     });
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        [](const utility::string_t&){});
 
     ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
     ws_transport->disconnect().get();
@@ -298,8 +296,7 @@ void receive_loop_logs_exception_runner(const T& e, const utility::string_t& exp
 
     std::shared_ptr<log_writer> writer(std::make_shared<memory_log_writer>());
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::errors, writer), [](const utility::string_t&){});
+    auto ws_transport = websocket_transport::create(client, logger(writer, trace_level::errors), [](const utility::string_t&){});
 
     ws_transport->connect(_XPLATSTR("url"))
         .then([&receive_event]()
@@ -336,8 +333,8 @@ TEST(websocket_transport_receive_loop, process_response_callback_called_when_mes
         process_response_event->set();
     };
 
-    auto ws_transport = websocket_transport::create(client, connection_impl::create(_XPLATSTR("http://fake.uri"),
-        _XPLATSTR(""), trace_level::none, std::make_shared<trace_log_writer>()), process_response);
+    auto ws_transport = websocket_transport::create(client, logger(std::make_shared<trace_log_writer>(), trace_level::none),
+        process_response);
 
     ws_transport->connect(_XPLATSTR("http://fakeuri.org")).get();
 


### PR DESCRIPTION
...ports

The only reason why transports were coupled to the `connection_impl` was because they needed to be able to log things. However this would create a circular reference between a transport and `connection_impl` (in the future) which would lead to memory leaks. One of the ways to avoid the leak would be to use a `weak_ptr<connection_impl>` but since we only want to get a logger it is just better to pass the logger instead of the connection. This not only removes the situation leading to memory leaks but also makes testing easier. If we end up needing a reference to `connection_impl` in the future we will revisit.
