### PR TITLE
ThouShaltNotPassCancellationTokenToTaskValuedContinuations

### DIFF
--- a/src/signalrclient/default_websocket_client.cpp
+++ b/src/signalrclient/default_websocket_client.cpp
@@ -20,6 +20,7 @@ namespace signalr
 
     pplx::task<std::string> default_websocket_client::receive()
     {
+        // the caller is responsible for observing exceptions
         return m_underlying_client.receive()
             .then([](web_sockets::client::websocket_incoming_message msg)
             {


### PR DESCRIPTION
Fixing an issue where the continuation that is used to observe exceptions inside the receive loop in the websocket transport would be cancelled because it took a cancellation token that had been cancelled because the transport is being disconnected. If in this state the receive task had thrown an exception (which is pretty much guaranteed because when disconnecting the websocket is closed when the receive task is still pending) we would not have observe the exception. This unobserved exception would crash the process. The fix is to separate the continuation into two - one that is value based, takes the cancellation token, reads the message content and schedules the next iteration and one that is task based and does not take a cancellation token. The first one may not run in case of exceptions or when the cancellation token is set to cancelled while the second one is guaranteed to run in case of exceptions or cancellation.
