### PR TITLE
Fixed error RC1107 when consumers compile their resource file.

### DIFF
--- a/NuGet/Microsoft.AspNet.SignalR.Client.Cpp.WinDesktop.targets.template
+++ b/NuGet/Microsoft.AspNet.SignalR.Client.Cpp.WinDesktop.targets.template
@@ -3,10 +3,10 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
Hit this error while trying to build:

`2>RC : fatal error RC1107: invalid usage; use RC /? for Help`

Caused by the argument `/I"...\packages\Microsoft.AspNet.SignalR.Client.Cpp.v140.WinDesktop.1.0.0-beta1\build\native\include\"` passed to `rc.exe`. It turned out that it doesn't like the trailing backslash.
