### PR TITLE
Fixing serializing string twice in persistent connection

### DIFF
--- a/src/signalrclient/connection_impl.cpp
+++ b/src/signalrclient/connection_impl.cpp
@@ -752,7 +752,7 @@ namespace signalr
     {
         set_message_received_json([message_received](const web::json::value& payload)
         {
-            message_received(payload.serialize());
+            message_received(payload.is_string() ? payload.as_string() : payload.serialize());
         });
     }
 

--- a/test/signalrclienttests/connection_impl_tests.cpp
+++ b/test/signalrclienttests/connection_impl_tests.cpp
@@ -470,12 +470,12 @@ TEST(connection_impl_set_message_received, callback_invoked_when_message_receive
 
     auto message_received_event = std::make_shared<event>();
     connection->set_message_received_string([message, message_received_event](const utility::string_t &m){
-        if (m == _XPLATSTR("\"Test\""))
+        if (m == _XPLATSTR("Test"))
         {
             *message = m;
         }
 
-        if (m == _XPLATSTR("\"release\""))
+        if (m == _XPLATSTR("release"))
         {
             message_received_event->set();
         }
@@ -485,7 +485,7 @@ TEST(connection_impl_set_message_received, callback_invoked_when_message_receive
 
     ASSERT_FALSE(message_received_event->wait(5000));
 
-    ASSERT_EQ(_XPLATSTR("\"Test\""), *message);
+    ASSERT_EQ(_XPLATSTR("Test"), *message);
 }
 
 TEST(connection_impl_set_message_received, exception_from_callback_caught_and_logged)
@@ -512,12 +512,12 @@ TEST(connection_impl_set_message_received, exception_from_callback_caught_and_lo
 
     auto message_received_event = std::make_shared<event>();
     connection->set_message_received_string([message_received_event](const utility::string_t &m){
-        if (m == _XPLATSTR("\"throw\""))
+        if (m == _XPLATSTR("throw"))
         {
             throw std::runtime_error("oops");
         }
 
-        if (m == _XPLATSTR("\"release\""))
+        if (m == _XPLATSTR("release"))
         {
             message_received_event->set();
         }
@@ -559,12 +559,12 @@ TEST(connection_impl_set_message_received, non_std_exception_from_callback_caugh
     auto message_received_event = std::make_shared<event>();
     connection->set_message_received_string([message_received_event](const utility::string_t &m)
     {
-        if (m == _XPLATSTR("\"throw\""))
+        if (m == _XPLATSTR("throw"))
         {
             throw 42;
         }
 
-        if (m == _XPLATSTR("\"release\""))
+        if (m == _XPLATSTR("release"))
         {
             message_received_event->set();
         }


### PR DESCRIPTION
Since SignalR payloads are Json we parse the incoming message as a Json object and extract the actual message. For persistent connections the api is a string based so we need to turn the message back to string. We used to always serialize it but if the value is already a string it causes double escaping. The fix is to check if the value is a string and if it is just pass it down to the receive handler, otherwise (e.g. it is a json object or a number etc.) we serialize it back to string as we did before.

Issue: #128