### PR TITLE
Enabling configuring UseHardLinkIfPossible

### DIFF
--- a/NuGet/Microsoft.AspNet.SignalR.Client.Cpp.WinDesktop.targets.template
+++ b/NuGet/Microsoft.AspNet.SignalR.Client.Cpp.WinDesktop.targets.template
@@ -32,7 +32,11 @@
   </ItemDefinitionGroup>
 
   <Target Name="signalrclient_AfterBuild" AfterTargets="AfterBuild">
-    <Copy DestinationFolder="$(TargetDir)" SourceFiles="@(CopyToOutput)" SkipUnchangedFiles="true" UseHardlinksIfPossible="true">
+    <PropertyGroup>
+      <UseHardlinksIfPossible Condition="'$(UseHardlinksIfPossible)' == ''">true</UseHardlinksIfPossible>
+    </PropertyGroup>
+
+    <Copy DestinationFolder="$(TargetDir)" SourceFiles="@(CopyToOutput)" SkipUnchangedFiles="true" UseHardlinksIfPossible="$(UseHardlinksIfPossible)">
       <Output TaskParameter="DestinationFiles" PropertyName="DestinationFiles" />
       <Output TaskParameter="DestinationFiles" ItemName="DestinationFiles" />
       <Output TaskParameter="CopiedFiles" PropertyName="CopiedFiles" />


### PR DESCRIPTION
Some builds fail due to: "Creating hard-links during the build is not allowed. When building target, the following outputs have multiple hard-links...". This change makes it possible to override the default when running the build in such environments.