### PR TITLE
Add missing .cpp to CMakeLists.txt

### DIFF
--- a/src/signalrclient/CMakeLists.txt
+++ b/src/signalrclient/CMakeLists.txt
@@ -12,6 +12,7 @@ set (SOURCES
  internal_hub_proxy.cpp
  logger.cpp
  request_sender.cpp
+ signalr_client_config.cpp
  stdafx.cpp
  trace_log_writer.cpp
  transport.cpp


### PR DESCRIPTION
When signalr_client_config.cpp was created it was not added in the cmake files, resulting in a non-working library. This PR fixes that.